### PR TITLE
Open application upon build success

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Builds have been tested on both Linux and Windows 10.
 #### Build Requirements
 
 - gcc g++, clang or MSVC Compiler (depending upon your operating system)
+- cmake
 
 
 #### Build Dependencies
@@ -33,13 +34,10 @@ Once the variables have been set correctly, it should be as simple as opening a 
 issuing the command:
 
 ```
-git clone https://github.com/lpsandaruwan/savior-ship.git
-cd savior-ship\windows
-
 build.cmd
 ```
 
-Once the project has sucessfully built, you can then make your changes to the source code and run **build.cmd** again. Doing so will quickly rebuild the project's binaries for you.
+Once the project has successfully built, you can then make your changes to the source code and run **build.cmd** again. Doing so will quickly rebuild the project's binaries for you.
 
 #### Build in Linux
 

--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -8,7 +8,6 @@
 :: C++ Core features.
 
 :: Cmake is available from https://cmake.org/
-:: Powershell comes preinstalled with Windows 10
 :: Git, the Win 10 SDK and the Win universal runtime, etc can all be installed
 :: via the individual components section of the MS Visual Studio installer.
 
@@ -44,11 +43,11 @@ SET BUILDDIR=%SCRIPTDIR%\..\build
 
 CD %SCRIPTDIR%\..\
 
-CALL %MSVSDIR%"\VC\Auxiliary\Build\vcvars64.bat"
+IF exist %MSVSDIR%"\VC\Auxiliary\Build\vcvars64.bat" ( CALL %MSVSDIR%"\VC\Auxiliary\Build\vcvars64.bat" ) ELSE ( ECHO vcvars64.bat not found. Please ensure the correct path is set inside the variable MSVSDIR. )
 
 :pullvcpkg
 
-IF exist %VCPKGDIR% (  GOTO :cleanbuild )
+IF exist %VCPKGDIR% ( GOTO :cleanbuild )
 
 MKDIR %VCPKGDIR% && CD %VCPKGDIR% && git init
 git fetch https://github.com/Microsoft/vcpkg master
@@ -63,7 +62,7 @@ CD %SCRIPTDIR%\..\
 
 :cleanbuild
 
-IF exist %BUILDDIR% (  RMDIR /Q /S "%BUILDDIR%" )
+IF exist %BUILDDIR% ( RMDIR /Q /S "%BUILDDIR%" )
 
 MKDIR %BUILDDIR% && CD %BUILDDIR%
 
@@ -76,9 +75,11 @@ cmake .. %GENERATOR% ^
 
 msbuild /m ".\savior.sln" /p:configuration=%CONFIGURATION% /p:platform=x64 /p:PlatformToolset=%TOOLSET%
 
-COPY %VCRUN% %BUILDDIR%\%CONFIGURATION%
+IF exist %VCRUN% ( COPY %VCRUN% %BUILDDIR%\%CONFIGURATION% ) ELSE ( ECHO vcruntime140_1.dll not found. Please ensure the correct path is set inside the variable VCRUN. )
 
 ECHO #
 ECHO    Build complete!
 ECHO    Successfully built binaries can be found inside the folder \build\%CONFIGURATION%
 ECHO #
+
+IF exist %BUILDDIR%\%CONFIGURATION%\savior.exe ( START /D %BUILDDIR%\%CONFIGURATION% savior.exe )


### PR DESCRIPTION
If the build succeeds then the application
exe will run. This allows for very quick
testing of changes.
The build script will now print a
message to the screen if the variables
MSVSDIR or VCRUN are incorrectly set.
There are also some small fixes to the
README.md correcting some hastily written
instructions.